### PR TITLE
Remove outdated model documentation from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,6 @@ RUN set -e; \
 # --- PART 3.5: Model download scripts ---
 
 # Copy model documentation and scripts into the image
-COPY comfyui_models_complete_library.md /workspace/
 COPY scripts/verify_links.py scripts/download_models.py /workspace/scripts/
 
 # Create virtual environment for download scripts


### PR DESCRIPTION
This pull request makes a minor change to the Docker build process by removing the `comfyui_models_complete_library.md` documentation file from being copied into the image. This helps keep the image smaller and ensures only necessary files are included.