### PR TITLE
Refactor: Update script paths and virtual environment locations

### DIFF
--- a/CODEX_SETUP.md
+++ b/CODEX_SETUP.md
@@ -130,7 +130,7 @@ MODELS = {
 
 Then run:
 ```bash
-python3 /workspace/scripts/download_models.py
+python3 /opt/runpod/scripts/download_models.py
 ```
 
 ---
@@ -154,7 +154,7 @@ tail -50 /workspace/logs/model_download.log
 
 # Manually download models
 cd /workspace
-python3 scripts/download_models.py
+python3 /opt/runpod/scripts/download_models.py
 ```
 
 ### Out of disk space?

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,8 @@ RUN set -e; \
 
 # Copy model documentation and scripts into the image
 COPY comfyui_models_complete_library.md /opt/runpod/
-COPY scripts/verify_links.py scripts/download_models.py /opt/runpod/scripts/
+RUN mkdir -p /opt/runpod/scripts
+COPY scripts/verify_links.py scripts/download_models.py scripts/manual_download.sh /opt/runpod/scripts/
 
 # Create virtual environment for download scripts
 RUN python3 -m venv /opt/runpod/model_dl_venv && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,12 +74,11 @@ RUN set -e; \
 
 # Copy model documentation and scripts into the image
 COPY comfyui_models_complete_library.md /opt/runpod/
-COPY scripts/verify_links.py scripts/download_models.py /workspace/scripts/
+COPY scripts/verify_links.py scripts/download_models.py /opt/runpod/scripts/
 
 # Create virtual environment for download scripts
-RUN cd /workspace && \
-    python3 -m venv model_dl_venv && \
-    /workspace/model_dl_venv/bin/pip install --no-cache-dir requests==2.31.0
+RUN python3 -m venv /opt/runpod/model_dl_venv && \
+    /opt/runpod/model_dl_venv/bin/pip install --no-cache-dir requests==2.31.0
 
 # Create model download script (runs only when DOWNLOAD_MODELS=true)
 RUN <<'EOF' cat > /usr/local/bin/download_comfyui_models.sh
@@ -134,10 +133,10 @@ if [ "$DOWNLOAD_MODELS" = "true" ]; then
 
     # Check if virtual environment exists
     echo "🔍 DEBUG: Checking virtual environment..."
-    if [ -d "model_dl_venv" ]; then
+    if [ -d "/opt/runpod/model_dl_venv" ]; then
         echo "✅ Virtual environment found"
         echo "🔍 DEBUG: Checking activation script..."
-        if [ -f "model_dl_venv/bin/activate" ]; then
+        if [ -f "/opt/runpod/model_dl_venv/bin/activate" ]; then
             echo "✅ Activation script found"
         else
             echo "❌ Activation script missing!"
@@ -150,15 +149,15 @@ if [ "$DOWNLOAD_MODELS" = "true" ]; then
 
     # Check if scripts exist
     echo "🔍 DEBUG: Checking download scripts..."
-    if [ -f "/workspace/scripts/verify_links.py" ]; then
+    if [ -f "/opt/runpod/scripts/verify_links.py" ]; then
         echo "✅ verify_links.py found"
     else
         echo "❌ verify_links.py NOT found"
-        echo "Available files in /workspace/scripts/:"
-        ls -la /workspace/scripts/ || true
+        echo "Available files in /opt/runpod/scripts/:"
+        ls -la /opt/runpod/scripts/ || true
     fi
 
-    if [ -f "/workspace/scripts/download_models.py" ]; then
+    if [ -f "/opt/runpod/scripts/download_models.py" ]; then
         echo "✅ download_models.py found"
     else
         echo "❌ download_models.py NOT found"
@@ -176,7 +175,7 @@ if [ "$DOWNLOAD_MODELS" = "true" ]; then
 
         # Activate virtual environment
         echo \"🔍 DEBUG: Activating virtual environment...\"
-        source model_dl_venv/bin/activate || {
+        source /opt/runpod/model_dl_venv/bin/activate || {
             echo \"❌ Failed to activate virtual environment!\"
             exit 1
         }
@@ -185,7 +184,7 @@ if [ "$DOWNLOAD_MODELS" = "true" ]; then
         echo \"🔍 DEBUG: Checking for link verification results...\"
         if [ ! -f \"link_verification_results.json\" ]; then
             echo \"🔍 Checking link accessibility...\"
-            if ! python3 /workspace/scripts/verify_links.py; then
+            if ! python3 /opt/runpod/scripts/verify_links.py; then
                 verify_exit=\$?
                 echo \"❌ Link verification failed!\"
                 echo \"   Exit code: \$verify_exit\"
@@ -209,7 +208,7 @@ if [ "$DOWNLOAD_MODELS" = "true" ]; then
 
         # Download models
         echo \"⬇️  Starting model download...\"
-        if ! python3 /workspace/scripts/download_models.py /workspace; then
+        if ! python3 /opt/runpod/scripts/download_models.py /workspace; then
             download_exit=\$?
             echo \"❌ Model download failed!\"
             echo \"   Exit code: \$download_exit\"

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN set -e; \
 COPY comfyui_models_complete_library.md /opt/runpod/
 RUN mkdir -p /opt/runpod/scripts
 COPY scripts/verify_links.py scripts/download_models.py scripts/manual_download.sh /opt/runpod/scripts/
+RUN chmod +x /opt/runpod/scripts/*.sh
 
 # Create virtual environment for download scripts
 RUN python3 -m venv /opt/runpod/model_dl_venv && \

--- a/README.md
+++ b/README.md
@@ -127,24 +127,53 @@ docker buildx build --platform linux/amd64 -f Dockerfile -t ecomtree/comfyui-clo
 ./scripts/test.sh
 ```
 
+### Deployment Checklist
+
+```bash
+# Build image locally
+./scripts/build.sh
+
+docker run -it \
+  -e DOWNLOAD_MODELS=true \
+  -e JUPYTER_ENABLE=true \
+  -e HF_TOKEN=<optional-hf-token> \
+  -p 8188:8188 \
+  -p 8888:8888 \
+  -v $(pwd)/workspace:/workspace \
+  ecomtree/comfyui-cloud:latest
+
+# Inside container, confirm Jupyter
+curl http://localhost:8888
+
+# Confirm download logs
+cat /workspace/model_download.log
+```
+
 ## 🔧 Configuration
 
 ### 🤖 Automatic Model Download
 
 The image supports automatic downloading of all validated ComfyUI models at startup:
 
-**Option 1: RunPod Environment Variable**
+**Option 1: RunPod Environment Variables**
 
 ```bash
 # In RunPod Pod Settings under "Environment Variables"
 DOWNLOAD_MODELS=true
 HF_TOKEN=hf_xxxxxxxxxxxxx  # Optional: for protected Hugging Face models
+JUPYTER_ENABLE=true        # Optional: enable Jupyter Lab on port 8888
 ```
 
 **Option 2: Docker Run**
 
 ```bash
-docker run -e DOWNLOAD_MODELS=true -e HF_TOKEN=hf_xxx ecomtree/comfyui-cloud:latest
+docker run \
+  -e DOWNLOAD_MODELS=true \
+  -e HF_TOKEN=hf_xxx \
+  -e JUPYTER_ENABLE=true \
+  -p 8188:8188 \
+  -p 8888:8888 \
+  ecomtree/comfyui-cloud:latest
 ```
 
 **Manual Download (in running container)**
@@ -154,8 +183,10 @@ docker run -e DOWNLOAD_MODELS=true -e HF_TOKEN=hf_xxx ecomtree/comfyui-cloud:lat
 docker exec -it <container_name> /usr/local/bin/download_comfyui_models.sh
 
 # Or Python script directly
-docker exec -it <container_name> python3 /workspace/scripts/download_models.py /workspace
+docker exec -it <container_name> python3 /opt/runpod/scripts/download_models.py /workspace
 ```
+
+> See `docs/environment-variables.md` for the full list of tunables.
 
 **Notes:**
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ cat /workspace/model_download.log
 
 The image supports automatic downloading of all validated ComfyUI models at startup:
 
-**Option 1: RunPod Environment Variables**
+### Option 1: RunPod Environment Variables
 
 ```bash
 # In RunPod Pod Settings under "Environment Variables"
@@ -164,7 +164,7 @@ HF_TOKEN=hf_xxxxxxxxxxxxx  # Optional: for protected Hugging Face models
 JUPYTER_ENABLE=true        # Optional: enable Jupyter Lab on port 8888
 ```
 
-**Option 2: Docker Run**
+### Option 2: Docker Run
 
 ```bash
 docker run \

--- a/README_MODELS.md
+++ b/README_MODELS.md
@@ -47,8 +47,8 @@ Oder direkt mit Python:
 ```bash
 # Im Container
 cd /workspace
-source model_dl_venv/bin/activate
-python3 scripts/download_models.py /workspace
+source /opt/runpod/model_dl_venv/bin/activate
+python3 /opt/runpod/scripts/download_models.py /workspace
 ```
 
 ## Voraussetzungen
@@ -140,9 +140,9 @@ docker logs <container_name> | tail -50
 # Model-Download manuell triggern
 docker exec <container_name> bash -c "
     cd /workspace
-    source model_dl_venv/bin/activate
-    python3 scripts/verify_links.py
-    python3 scripts/download_models.py /workspace
+    source /opt/runpod/model_dl_venv/bin/activate
+    python3 /opt/runpod/scripts/verify_links.py
+    python3 /opt/runpod/scripts/download_models.py /workspace
 "
 ```
 
@@ -152,10 +152,10 @@ Für eine interaktivere Erfahrung gibt es ein spezielles Manual-Download-Script:
 
 ```bash
 # Im Container ausführen
-docker exec -it <container_name> /workspace/scripts/manual_download.sh
+docker exec -it <container_name> /opt/runpod/scripts/manual_download.sh
 
 # Oder direkt aus dem Host
-docker exec <container_name> bash /workspace/scripts/manual_download.sh
+docker exec <container_name> bash /opt/runpod/scripts/manual_download.sh
 ```
 
 Das Manual-Download-Script bietet:
@@ -180,8 +180,8 @@ Das Manual-Download-Script bietet:
 ```bash
 # Erneut versuchen
 cd /workspace
-source model_dl_venv/bin/activate
-python3 scripts/download_models.py /workspace
+source /opt/runpod/model_dl_venv/bin/activate
+python3 /opt/runpod/scripts/download_models.py /workspace
 ```
 
 ### Speicherplatz prüfen

--- a/README_MODELS.md
+++ b/README_MODELS.md
@@ -199,8 +199,8 @@ du -sh /workspace/ComfyUI/models/*
 ```bash
 # Links erneut überprüfen
 cd /workspace
-source model_dl_venv/bin/activate
-python3 scripts/verify_links.py
+source /opt/runpod/model_dl_venv/bin/activate
+python3 /opt/runpod/scripts/verify_links.py
 ```
 
 ## Statistiken

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,33 @@
+# RunPod Environment Variables
+
+## Required Variables
+
+### Enable Jupyter Lab
+- **Variable**: `JUPYTER_ENABLE`
+- **Value**: `true`
+- **Description**: Launches Jupyter Lab on port 8888 without authentication.
+
+### Enable Model Downloads
+- **Variable**: `DOWNLOAD_MODELS`
+- **Value**: `true`
+- **Description**: Starts the automatic ComfyUI model download routine during container boot.
+
+## Optional Variables
+
+### Hugging Face Token
+- **Variable**: `HF_TOKEN`
+- **Value**: `<your-hf-token>`
+- **Description**: Grants access to gated Hugging Face models while downloading.
+
+### Custom Workspace Path
+- **Variable**: `WORKSPACE_DIR`
+- **Value**: `/workspace`
+- **Description**: Override only if your RunPod volume mounts to a different path.
+
+## Usage Tips
+- Set these variables in the RunPod pod template before launching.
+- When running locally, pass them with `docker run -e VAR=value`.
+- For sensitive values such as `HF_TOKEN`, prefer RunPod secrets or `.env` files.
+### Ports
+- **Port 8188**: ComfyUI web interface.
+- **Port 8888**: Jupyter Lab (only available when `JUPYTER_ENABLE=true`).

--- a/scripts/manual_download.sh
+++ b/scripts/manual_download.sh
@@ -27,13 +27,13 @@ fi
 # Check if virtual environment exists
 echo ""
 echo "🔍 Checking virtual environment..."
-if [ ! -d "model_dl_venv" ]; then
+if [ ! -d "/opt/runpod/model_dl_venv" ]; then
     echo "❌ Virtual environment not found!"
     echo "💡 This suggests the container wasn't built correctly"
     exit 1
 fi
 
-if [ ! -f "model_dl_venv/bin/activate" ]; then
+if [ ! -f "/opt/runpod/model_dl_venv/bin/activate" ]; then
     echo "❌ Virtual environment activation script missing!"
     exit 1
 fi
@@ -43,12 +43,12 @@ echo "✅ Virtual environment found"
 # Check if scripts exist
 echo ""
 echo "🔍 Checking download scripts..."
-if [ ! -f "scripts/verify_links.py" ]; then
+if [ ! -f "/opt/runpod/scripts/verify_links.py" ]; then
     echo "❌ verify_links.py not found!"
     exit 1
 fi
 
-if [ ! -f "scripts/download_models.py" ]; then
+if [ ! -f "/opt/runpod/scripts/download_models.py" ]; then
     echo "❌ download_models.py not found!"
     exit 1
 fi
@@ -108,7 +108,7 @@ echo "🚀 Step 1: Verifying links..."
 echo "This may take a few minutes..."
 echo ""
 
-source model_dl_venv/bin/activate
+source /opt/runpod/model_dl_venv/bin/activate
 
 if [ -z "$VIRTUAL_ENV" ]; then
     echo "❌ Failed to activate virtual environment!"
@@ -117,7 +117,7 @@ fi
 
 echo "✅ Virtual environment activated: $VIRTUAL_ENV"
 
-python3 scripts/verify_links.py
+python3 /opt/runpod/scripts/verify_links.py
 
 if [ ! -f "link_verification_results.json" ]; then
     echo "❌ Link verification failed!"
@@ -170,7 +170,7 @@ if [ -t 0 ]; then
 fi
 
 echo "⬇️  Starting download..."
-python3 scripts/download_models.py /workspace
+python3 /opt/runpod/scripts/download_models.py /workspace
 
 echo ""
 echo "✅ Manual download completed!"


### PR DESCRIPTION
This pull request standardizes the directory structure for model download scripts and their virtual environment across the Docker image and documentation. All related scripts and environments have been moved from `/workspace/scripts` and `/workspace/model_dl_venv` to `/opt/runpod/scripts` and `/opt/runpod/model_dl_venv`. The documentation and scripts have been updated to reflect these changes, and new documentation has been added for environment variables.

**Directory and path standardization:**

* All references to model download scripts (`download_models.py`, `verify_links.py`, `manual_download.sh`) and their virtual environment have been updated from `/workspace/scripts` and `/workspace/model_dl_venv` to `/opt/runpod/scripts` and `/opt/runpod/model_dl_venv` in the `Dockerfile`, `CODEX_SETUP.md`, `README.md`, `README_MODELS.md`, and `scripts/manual_download.sh`. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L77-R81) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L137-R139) [[3]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L153-R160) [[4]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L179-R178) [[5]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L188-R187) [[6]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L212-R211) [[7]](diffhunk://#diff-0eafabe90878d2a3fb22c638f1742ffe5b8e60958a98f2c951bc38e345db6718L133-R133) [[8]](diffhunk://#diff-0eafabe90878d2a3fb22c638f1742ffe5b8e60958a98f2c951bc38e345db6718L157-R157) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L157-R190) [[10]](diffhunk://#diff-8ef500f5f4e7b81afea31e32b1f44e7fb9cc34f68a581e58d3314388acefbf29L50-R51) [[11]](diffhunk://#diff-8ef500f5f4e7b81afea31e32b1f44e7fb9cc34f68a581e58d3314388acefbf29L143-R145) [[12]](diffhunk://#diff-8ef500f5f4e7b81afea31e32b1f44e7fb9cc34f68a581e58d3314388acefbf29L155-R158) [[13]](diffhunk://#diff-8ef500f5f4e7b81afea31e32b1f44e7fb9cc34f68a581e58d3314388acefbf29L183-R184) [[14]](diffhunk://#diff-6116525f0b52f3d6225311861860e9e51a7863888da45fddcd21e8a4ecb51791L30-R36) [[15]](diffhunk://#diff-6116525f0b52f3d6225311861860e9e51a7863888da45fddcd21e8a4ecb51791L46-R51) [[16]](diffhunk://#diff-6116525f0b52f3d6225311861860e9e51a7863888da45fddcd21e8a4ecb51791L111-R111) [[17]](diffhunk://#diff-6116525f0b52f3d6225311861860e9e51a7863888da45fddcd21e8a4ecb51791L120-R120) [[18]](diffhunk://#diff-6116525f0b52f3d6225311861860e9e51a7863888da45fddcd21e8a4ecb51791L173-R173)

**Documentation updates:**

* All usage instructions and code examples in `README.md`, `README_MODELS.md`, and `CODEX_SETUP.md` have been updated to use the new `/opt/runpod/scripts` and `/opt/runpod/model_dl_venv` paths. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R130-R176) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L157-R190) [[3]](diffhunk://#diff-8ef500f5f4e7b81afea31e32b1f44e7fb9cc34f68a581e58d3314388acefbf29L50-R51) [[4]](diffhunk://#diff-8ef500f5f4e7b81afea31e32b1f44e7fb9cc34f68a581e58d3314388acefbf29L143-R145) [[5]](diffhunk://#diff-8ef500f5f4e7b81afea31e32b1f44e7fb9cc34f68a581e58d3314388acefbf29L155-R158) [[6]](diffhunk://#diff-8ef500f5f4e7b81afea31e32b1f44e7fb9cc34f68a581e58d3314388acefbf29L183-R184) [[7]](diffhunk://#diff-0eafabe90878d2a3fb22c638f1742ffe5b8e60958a98f2c951bc38e345db6718L133-R133) [[8]](diffhunk://#diff-0eafabe90878d2a3fb22c638f1742ffe5b8e60958a98f2c951bc38e345db6718L157-R157)

**New environment variable documentation:**

* Added a new file `docs/environment-variables.md` that documents all supported environment variables, their usage, and relevant ports for the container.

**Deployment and configuration improvements:**

* The deployment checklist and configuration sections in `README.md` have been expanded to include Jupyter Lab options and clarify environment variable usage for both local and RunPod deployments. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R130-R176) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L157-R190)

**Consistency and reliability:**

* All scripts now check for the existence of the virtual environment and scripts in the new standardized locations, improving reliability and consistency for both manual and automated model downloads. [[1]](diffhunk://#diff-6116525f0b52f3d6225311861860e9e51a7863888da45fddcd21e8a4ecb51791L30-R36) [[2]](diffhunk://#diff-6116525f0b52f3d6225311861860e9e51a7863888da45fddcd21e8a4ecb51791L46-R51) [[3]](diffhunk://#diff-6116525f0b52f3d6225311861860e9e51a7863888da45fddcd21e8a4ecb51791L111-R111) [[4]](diffhunk://#diff-6116525f0b52f3d6225311861860e9e51a7863888da45fddcd21e8a4ecb51791L120-R120) [[5]](diffhunk://#diff-6116525f0b52f3d6225311861860e9e51a7863888da45fddcd21e8a4ecb51791L173-R173)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves model download scripts and venv to `/opt/runpod`, updates Dockerfile and all docs/commands accordingly, and adds environment variable reference with deployment checklist.
> 
> - **Build/Dockerfile**:
>   - Relocate model scripts to `/opt/runpod/scripts` and create venv at `/opt/runpod/model_dl_venv`.
>   - Include `manual_download.sh`, set executable perms, and update all path checks/activations in `download_comfyui_models.sh`.
> - **Scripts**:
>   - Update `scripts/manual_download.sh` to use `/opt/runpod/model_dl_venv` and `/opt/runpod/scripts/*` and validate required files/dirs accordingly.
> - **Docs**:
>   - Update commands in `CODEX_SETUP.md`, `README.md`, and `README_MODELS.md` to new `/opt/runpod/...` paths.
>   - Add `docs/environment-variables.md` documenting `JUPYTER_ENABLE`, `DOWNLOAD_MODELS`, `HF_TOKEN`, `WORKSPACE_DIR`, and ports.
>   - Expand `README.md` with a deployment checklist and clearer env var/Jupyter examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0f8fdc60c35c9a624f9cf13ea64c474d71f3507. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an environment-variables reference with RunPod guidance and optional Jupyter toggle.
  * Added a deployment checklist, expanded run examples with clearer flags/ports, and updated model-download instructions and progress/logging notes.

* **Chores**
  * Consolidated model-download tooling to a consistent installation layout.
  * Improved manual download flow with additional validation, activation handling, and a post-download summary/reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->