### PR TITLE
Enhance Jupyter Lab setup and model download process

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The image supports automatic downloading of all validated ComfyUI models at star
 DOWNLOAD_MODELS=true
 HF_TOKEN=hf_xxxxxxxxxxxxx  # Optional: for protected Hugging Face models
 JUPYTER_ENABLE=true        # Optional: enable Jupyter Lab on port 8888
+JUPYTER_PASSWORD=mypass123 # Optional: set password for Jupyter (recommended for security)
 ```
 
 ### Option 2: Docker Run
@@ -171,6 +172,7 @@ docker run \
   -e DOWNLOAD_MODELS=true \
   -e HF_TOKEN=hf_xxx \
   -e JUPYTER_ENABLE=true \
+  -e JUPYTER_PASSWORD=mypass123 \
   -p 8188:8188 \
   -p 8888:8888 \
   ecomtree/comfyui-cloud:latest

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -5,7 +5,12 @@
 ### Enable Jupyter Lab
 - **Variable**: `JUPYTER_ENABLE`
 - **Value**: `true`
-- **Description**: Launches Jupyter Lab on port 8888 without authentication.
+- **Description**: Launches Jupyter Lab on port 8888.
+
+### Jupyter Password (Optional)
+- **Variable**: `JUPYTER_PASSWORD`
+- **Value**: `<your-password>`
+- **Description**: Sets a password for Jupyter Lab. If not provided, Jupyter will start without authentication (use only in trusted environments).
 
 ### Enable Model Downloads
 - **Variable**: `DOWNLOAD_MODELS`

--- a/scripts/HF-Model-Download.sh
+++ b/scripts/HF-Model-Download.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# --- START COPY & PASTE BLOCK ---
+
+# 1. DEIN HUGGING FACE API KEY (TOKEN)
+# Ersetze <DEIN_HF_API_KEY_HIER> mit deinem echten HF Token (findest du unter Settings -> Access Tokens)
+HF_TOKEN=""
+
+# 2. ÜBERPRÜFEN, OB DIE LIZENZ AKZEPTIERT WURDE
+echo "----------------------------------------------------------------"
+echo "WARNUNG: Hast du die Lizenz für 'FLUX.1-dev' auf Hugging Face akzeptiert?"
+echo "Link: https://huggingface.co/black-forest-labs/FLUX.1-dev"
+echo "Das Skript wird in 10 Sekunden fortgesetzt..."
+echo "Drücke STRG+C zum Abbrechen, falls nicht."
+echo "----------------------------------------------------------------"
+sleep 10
+
+# 3. ORDNERSTRUKTUR ERSTELLEN (FALLS NICHT VORHANDEN)
+echo "--- Erstelle Ordner (falls nicht vorhanden) ---"
+mkdir -p ./models/unet
+mkdir -p ./models/clip
+mkdir -p ./models/vae
+
+# 4. DOWNLOADS (FULL QUALITY / HEAVY VARIANTS)
+
+echo "--- [1/4] Download UNET (FLUX.1-dev) - Full Precision (23.8 GB) ---"
+# Das ist das Gated Model, braucht den API Key
+wget --header="Authorization: Bearer $HF_TOKEN" https://huggingface.co/black-forest-labs/FLUX.1-dev/resolve/main/flux1-dev.sft -O ./models/unet/flux1-dev.sft
+
+echo "--- [2/4] Download VAE (335 MB) ---"
+wget https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors -O ./models/vae/flux.ae.safetensors
+
+echo "--- [3/4] Download Großer Text Encoder (T5-XXL FP16 - 9.79 GB) ---"
+wget https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors -O ./models/clip/t5xxl_fp16.safetensors
+
+echo "--- [4/4] Download Kleiner Text Encoder (CLIP-L - 246 MB) ---"
+wget https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors -O ./models/clip/clip_l.safetensors
+
+echo "----------------------------------------------------------------"
+echo "--- Alle 'Heavy-Hitter' FLUX-Modelle sind downgeloadet. ---"
+echo "--- Ready to cook! 🚀 ---"
+
+# --- ENDE COPY & PASTE BLOCK ---


### PR DESCRIPTION
- Updated Dockerfile to improve Jupyter Lab authentication options, allowing for password protection.
- Modified environment variable handling for Jupyter password in the README and documentation.
- Added a new script for downloading Hugging Face models with user prompts for license acceptance.
- Ensured model download logs are created to prevent errors during execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional Jupyter password authentication, improves model download logging/env handling, and includes a Hugging Face model download helper script.
> 
> - **Runtime / Dockerfile**:
>   - **Jupyter Lab auth**: Start with password when `JUPYTER_PASSWORD` is set; otherwise explicitly start without auth.
>   - **Model downloads**: Pre-create `/workspace/model_download.log`; refine env handling in `download_comfyui_models.sh`.
> - **Docs**:
>   - **README** and `docs/environment-variables.md`: Document `JUPYTER_PASSWORD` and updated usage examples.
> - **Scripts**:
>   - Add `scripts/HF-Model-Download.sh` for downloading FLUX models from Hugging Face (token + license prompt).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9c579cf16eeeaa41317912aaa785bbd98de4e3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->