### PR TITLE
Enhance environment variable handling in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -522,7 +522,7 @@ touch /workspace/model_download.log
 /usr/local/bin/download_comfyui_models.sh
 
 # Wait for the background model downloader only when enabled
-if [ "${DOWNLOAD_MODELS_VALUE}" = "true" ]; then
+if [ "${DOWNLOAD_MODELS_VALUE:-false}" = "true" ]; then
     echo "⏳ Waiting for model download to start writing logs..."
     MAX_WAIT_SECONDS=${DOWNLOAD_LOG_WAIT_SECS:-10}
     WAIT_COUNT=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -458,7 +458,7 @@ echo "🔍 DEBUG: DOWNLOAD_MODELS raw='${DOWNLOAD_MODELS_DISPLAY}' normalized='$
 export DOWNLOAD_MODELS="${DOWNLOAD_MODELS_VALUE}"
 
 # Start Jupyter Lab in the background (port 8888)
-if [ "${JUPYTER_ENABLE_VALUE}" = "true" ]; then
+if [ "${JUPYTER_ENABLE_VALUE:-false}" = "true" ]; then
   echo "📊 Starting Jupyter Lab on port 8888..."
   cd /workspace
   

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,7 @@ DOWNLOAD_MODELS_DISPLAY="$DOWNLOAD_MODELS_RAW"
 if [ -z "$DOWNLOAD_MODELS_DISPLAY" ]; then
     DOWNLOAD_MODELS_DISPLAY="<unset>"
 fi
-if [ $DOWNLOAD_MODELS_STATUS -ne 0 ]; then
+if [ "$DOWNLOAD_MODELS_STATUS" -ne 0 ]; then
     echo "⚠️  Unrecognized value for DOWNLOAD_MODELS ('${DOWNLOAD_MODELS_DISPLAY}'). Defaulting to disabled."
 fi
 echo "   DOWNLOAD_MODELS raw='${DOWNLOAD_MODELS_DISPLAY}' normalized='${DOWNLOAD_MODELS_VALUE}'"

--- a/Dockerfile
+++ b/Dockerfile
@@ -443,7 +443,7 @@ DOWNLOAD_MODELS_DISPLAY="$DOWNLOAD_MODELS_RAW"
 if [ -z "$DOWNLOAD_MODELS_DISPLAY" ]; then
     DOWNLOAD_MODELS_DISPLAY="<unset>"
 fi
-if [ $DOWNLOAD_MODELS_STATUS -ne 0 ]; then
+if [ "$DOWNLOAD_MODELS_STATUS" -ne 0 ]; then
     echo "⚠️  Unrecognized value for DOWNLOAD_MODELS ('${DOWNLOAD_MODELS_DISPLAY}'). Defaulting to disabled."
 fi
 echo "🔍 DEBUG: DOWNLOAD_MODELS raw='${DOWNLOAD_MODELS_DISPLAY}' normalized='${DOWNLOAD_MODELS_VALUE}'"

--- a/Dockerfile
+++ b/Dockerfile
@@ -427,7 +427,7 @@ JUPYTER_ENABLE_DISPLAY="$JUPYTER_ENABLE_RAW"
 if [ -z "$JUPYTER_ENABLE_DISPLAY" ]; then
     JUPYTER_ENABLE_DISPLAY="<unset>"
 fi
-if [ $JUPYTER_ENABLE_STATUS -ne 0 ]; then
+if [ "$JUPYTER_ENABLE_STATUS" -ne 0 ]; then
     echo "⚠️  Unrecognized value for JUPYTER_ENABLE ('${JUPYTER_ENABLE_DISPLAY}'). Defaulting to disabled."
 fi
 echo "🔍 DEBUG: JUPYTER_ENABLE raw='${JUPYTER_ENABLE_DISPLAY}' normalized='${JUPYTER_ENABLE_VALUE}'"

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -5,7 +5,7 @@
 ### Enable Jupyter Lab
 - **Variable**: `JUPYTER_ENABLE`
 - **Value**: truthy (`true`, `1`, `yes`, `on`; case-insensitive)
-- **Description**: Launches Jupyter Lab on port 8888. Any other value disables Jupyter and triggers a startup warning.
+- **Description**: Launches Jupyter Lab on port 8888. Any other value (including unset) disables Jupyter Lab and triggers a startup warning for unrecognized values.
 
 ### Jupyter Password (Optional)
 - **Variable**: `JUPYTER_PASSWORD`
@@ -15,7 +15,7 @@
 ### Enable Model Downloads
 - **Variable**: `DOWNLOAD_MODELS`
 - **Value**: truthy (`true`, `1`, `yes`, `on`; case-insensitive)
-- **Description**: Starts the automatic ComfyUI model download routine during container boot. Download progress is written to `/workspace/model_download.log`.
+- **Description**: Starts the automatic ComfyUI model download routine during container boot. Download progress is written to `/workspace/model_download.log`. Any other value (including unset) disables model downloads; unrecognized values trigger a startup warning.
 
 ## Optional Variables
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -4,8 +4,8 @@
 
 ### Enable Jupyter Lab
 - **Variable**: `JUPYTER_ENABLE`
-- **Value**: `true`
-- **Description**: Launches Jupyter Lab on port 8888.
+- **Value**: truthy (`true`, `1`, `yes`, `on`; case-insensitive)
+- **Description**: Launches Jupyter Lab on port 8888. Any other value disables Jupyter and triggers a startup warning.
 
 ### Jupyter Password (Optional)
 - **Variable**: `JUPYTER_PASSWORD`
@@ -14,8 +14,8 @@
 
 ### Enable Model Downloads
 - **Variable**: `DOWNLOAD_MODELS`
-- **Value**: `true`
-- **Description**: Starts the automatic ComfyUI model download routine during container boot.
+- **Value**: truthy (`true`, `1`, `yes`, `on`; case-insensitive)
+- **Description**: Starts the automatic ComfyUI model download routine during container boot. Download progress is written to `/workspace/model_download.log`.
 
 ## Optional Variables
 


### PR DESCRIPTION
- Introduced a `normalize_flag` function to standardize boolean-like environment variable values for `DOWNLOAD_MODELS` and `JUPYTER_ENABLE`.
- Updated debug output to provide clearer information on the raw and normalized values of these variables.
- Improved handling of unrecognized values with warnings and defaults.
- Updated documentation to reflect the new truthy value acceptance for environment variables.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a shared flag normalizer and applies it to JUPYTER_ENABLE and DOWNLOAD_MODELS with clearer logging and warnings; updates docs to reflect flexible truthy values.
> 
> - **Docker/runtime**:
>   - **Shared flag normalization**: Add `normalize_flag.sh` to standardize boolean-like env vars (`true/1/yes/on`, case-insensitive).
>   - **Model downloads**: Update `download_comfyui_models.sh` to normalize `DOWNLOAD_MODELS`, improve debug output (raw vs. normalized), warn on unrecognized values, and start background downloads with logs in `/workspace/model_download.log`.
>   - **Startup script**: Update `start_comfyui_h200.sh` to normalize `JUPYTER_ENABLE` and `DOWNLOAD_MODELS`, gate Jupyter and log-wait behavior on normalized values, and enhance status messages.
> - **Docs**:
>   - Update `docs/environment-variables.md` to document flexible truthy values, default-disabled behavior, warnings on unrecognized values, and model download log location.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 233c9d6f4ee14afa7790e5f02386c5ed985834a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment flags now accept flexible truthy values (true, 1, yes, on; case-insensitive) and are normalized for consistent startup and background behavior.
  * Startup and background model-download flows now use normalized flag values and log both raw and normalized states.

* **Bug Fixes**
  * Added warnings and consistent handling for unrecognized or unset environment values when skipping services or downloads.

* **Documentation**
  * Updated environment variable docs to reflect flexible values, disabling behavior, and model-download logging details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->