### PR TITLE
Refactor Dockerfile to optimize cache usage for apt operations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ FROM ${BASE_IMAGE} AS builder
 ENV DEBIAN_FRONTEND=noninteractive \
     PIP_NO_CACHE_DIR=1
 
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apt,id=builder-apt-cache \
     apt-get update && apt-get install -y --no-install-recommends git jq ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
@@ -59,8 +58,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # --- PART 1 & 2: System setup & Python environment ---
 
 # Install system dependencies (with BuildKit caching)
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apt,id=runtime-apt-cache \
     apt-get update && apt-get upgrade -y && \
     apt-get install -y --no-install-recommends git wget curl unzip python3-venv jq ca-certificates tini && \
     apt-get clean && \


### PR DESCRIPTION
- Updated cache mount identifiers for improved clarity and management.
- Enhanced build efficiency by refining the apt-get installation process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Dockerfile apt cache mounts to named BuildKit caches for builder/runtime and removes the redundant /var/lib/apt cache mount.
> 
> - **Dockerfile**:
>   - **Builder stage**: Use BuildKit cache mount with id `builder-apt-cache` at `--mount=type=cache,target=/var/cache/apt`.
>   - **Runtime stage**: Use BuildKit cache mount with id `runtime-apt-cache` at `--mount=type=cache,target=/var/cache/apt`; remove redundant `--mount` for `target=/var/lib/apt`.
>   - Retains existing `apt-get` operations; only cache mounting strategy is updated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcd52e62a13e0fd2201892b9b9cd04fe4e102931. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build caching to improve build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->