### PR TITLE
fix: Add RunPod secrets support and improve Jupyter environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -538,7 +538,7 @@ read_secret_env() {
     # Only set if file exists and env var is unset
     if [ -f "$FILE_PATH" ] && [ -z "${!VAR_NAME:-}" ]; then
         echo "🔍 Reading $VAR_NAME from secrets file"
-        export "$VAR_NAME"="$(cat "$FILE_PATH" 2>/dev/null || echo '')"
+        export "${VAR_NAME}=$(cat "$FILE_PATH" 2>/dev/null || echo '')"
     fi
 }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -518,21 +518,19 @@ fi
 
 # RunPod Secret Support: Check for RunPod-style secret variables
 # RunPod may expose secrets as RUNPOD_SECRET_<NAME> or through /etc/runpod-volume/secrets/
-if [ -z "${JUPYTER_ENABLE:-}" ] && [ -n "${RUNPOD_SECRET_JUPYTER_ENABLE:-}" ]; then
-    echo "🔍 Using RUNPOD_SECRET_JUPYTER_ENABLE"
-    export JUPYTER_ENABLE="${RUNPOD_SECRET_JUPYTER_ENABLE}"
-fi
+secret_env() {
+    VAR_NAME="$1"
+    SECRET_VAR="RUNPOD_SECRET_${VAR_NAME}"
+    # Use indirect expansion to check and set variables
+    if [ -z "${!VAR_NAME:-}" ] && [ -n "${!SECRET_VAR:-}" ]; then
+        echo "🔍 Using ${SECRET_VAR}"
+        export "${VAR_NAME}=${!SECRET_VAR}"
+    fi
+}
 
-if [ -z "${DOWNLOAD_MODELS:-}" ] && [ -n "${RUNPOD_SECRET_DOWNLOAD_MODELS:-}" ]; then
-    echo "🔍 Using RUNPOD_SECRET_DOWNLOAD_MODELS"
-    export DOWNLOAD_MODELS="${RUNPOD_SECRET_DOWNLOAD_MODELS}"
-fi
-
-if [ -z "${HF_TOKEN:-}" ] && [ -n "${RUNPOD_SECRET_HF_TOKEN:-}" ]; then
-    echo "🔍 Using RUNPOD_SECRET_HF_TOKEN"
-    export HF_TOKEN="${RUNPOD_SECRET_HF_TOKEN}"
-fi
-
+secret_env "JUPYTER_ENABLE"
+secret_env "DOWNLOAD_MODELS"
+secret_env "HF_TOKEN"
 # Check for secrets file (alternative RunPod mechanism)
 if [ -f "/etc/runpod-volume/secrets/jupyter_enable" ] && [ -z "${JUPYTER_ENABLE:-}" ]; then
     echo "🔍 Reading JUPYTER_ENABLE from secrets file"

--- a/Dockerfile
+++ b/Dockerfile
@@ -544,6 +544,10 @@ if [ -f "/etc/runpod-volume/secrets/download_models" ] && [ -z "${DOWNLOAD_MODEL
     export DOWNLOAD_MODELS="$(cat /etc/runpod-volume/secrets/download_models 2>/dev/null || echo '')"
 fi
 
+if [ -f "/etc/runpod-volume/secrets/hf_token" ] && [ -z "${HF_TOKEN:-}" ]; then
+    echo "🔍 Reading HF_TOKEN from secrets file"
+    export HF_TOKEN="$(cat /etc/runpod-volume/secrets/hf_token 2>/dev/null || echo '')"
+fi
 # Normalize runtime feature flags
 JUPYTER_ENABLE_RAW="${JUPYTER_ENABLE:-}"
 set +e

--- a/Dockerfile
+++ b/Dockerfile
@@ -532,20 +532,19 @@ secret_env "JUPYTER_ENABLE"
 secret_env "DOWNLOAD_MODELS"
 secret_env "HF_TOKEN"
 # Check for secrets file (alternative RunPod mechanism)
-if [ -f "/etc/runpod-volume/secrets/jupyter_enable" ] && [ -z "${JUPYTER_ENABLE:-}" ]; then
-    echo "🔍 Reading JUPYTER_ENABLE from secrets file"
-    export JUPYTER_ENABLE="$(cat /etc/runpod-volume/secrets/jupyter_enable 2>/dev/null || echo '')"
-fi
+read_secret_env() {
+    VAR_NAME="$1"
+    FILE_PATH="$2"
+    # Only set if file exists and env var is unset
+    if [ -f "$FILE_PATH" ] && [ -z "${!VAR_NAME:-}" ]; then
+        echo "🔍 Reading $VAR_NAME from secrets file"
+        export "$VAR_NAME"="$(cat "$FILE_PATH" 2>/dev/null || echo '')"
+    fi
+}
 
-if [ -f "/etc/runpod-volume/secrets/download_models" ] && [ -z "${DOWNLOAD_MODELS:-}" ]; then
-    echo "🔍 Reading DOWNLOAD_MODELS from secrets file"
-    export DOWNLOAD_MODELS="$(cat /etc/runpod-volume/secrets/download_models 2>/dev/null || echo '')"
-fi
-
-if [ -f "/etc/runpod-volume/secrets/hf_token" ] && [ -z "${HF_TOKEN:-}" ]; then
-    echo "🔍 Reading HF_TOKEN from secrets file"
-    export HF_TOKEN="$(cat /etc/runpod-volume/secrets/hf_token 2>/dev/null || echo '')"
-fi
+read_secret_env "JUPYTER_ENABLE" "/etc/runpod-volume/secrets/jupyter_enable"
+read_secret_env "DOWNLOAD_MODELS" "/etc/runpod-volume/secrets/download_models"
+read_secret_env "HF_TOKEN" "/etc/runpod-volume/secrets/hf_token"
 # Normalize runtime feature flags
 JUPYTER_ENABLE_RAW="${JUPYTER_ENABLE:-}"
 set +e

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ The image includes an advanced model download system with parallel downloads, ch
 
 ### Option 1: RunPod Environment Variables
 
+**IMPORTANT:** In RunPod, you MUST click the "Save" button at the bottom of the Environment Variables section **BEFORE** deploying the pod!
+
 ```bash
 # In RunPod Pod Settings under "Environment Variables"
 DOWNLOAD_MODELS=true
@@ -230,6 +232,24 @@ DOWNLOAD_MAX_WORKERS=4         # Number of parallel download workers (default: 4
 HF_TOKEN=hf_xxxxxxxxxxxxx      # Optional: for protected Hugging Face models
 JUPYTER_ENABLE=true            # Optional: enable Jupyter Lab on port 8888
 JUPYTER_PASSWORD=<your-secure-password> # Optional: enable Jupyter with password
+```
+
+**RunPod Setup Steps:**
+1. Go to your template settings
+2. Scroll to "Environment Variables"
+3. Add each variable **one by one**:
+   - Click "+ Environment Variable"
+   - Enter `JUPYTER_ENABLE` as key
+   - Enter `true` as value
+   - Click the ✓ (checkmark) to confirm
+4. **IMPORTANT:** Click "Save" at the bottom
+5. **Then** deploy your pod
+
+**Troubleshooting:** If Jupyter doesn't start, the variables might not be set. Check the logs:
+```bash
+# SSH into your pod and run:
+env | grep -E "JUPYTER|DOWNLOAD|RUNPOD"
+# You should see your variables listed
 ```
 
 ### Option 2: Docker Run

--- a/docs/RUNPOD_JUPYTER_FIX.md
+++ b/docs/RUNPOD_JUPYTER_FIX.md
@@ -1,0 +1,135 @@
+# RunPod Jupyter Lab Fix Guide 🚀
+
+## Problem
+Jupyter Lab doesn't start even though `JUPYTER_ENABLE=true` is set in RunPod.
+
+## Root Cause
+RunPod environment variables are sometimes not properly passed to the container, resulting in empty values.
+
+## Solution
+
+### Option 1: Rebuild with Fixed Image (Recommended)
+
+The new image version includes automatic detection of RunPod secrets and better error handling.
+
+**Steps:**
+1. Stop your current pod
+2. Go to your template settings
+3. Update the Docker image to the latest version
+4. Ensure environment variables are **saved** (click "Save" button!)
+5. Deploy a new pod
+
+### Option 2: Manual Workaround (Current Pod)
+
+If you can't redeploy, you can manually start Jupyter:
+
+**SSH into your pod and run:**
+
+```bash
+# 1. Check if variables are set
+env | grep -E "JUPYTER|DOWNLOAD|RUNPOD"
+
+# 2. If empty, manually export them
+export JUPYTER_ENABLE=true
+export JUPYTER_ALLOW_NO_AUTH=true
+export DOWNLOAD_MODELS=true
+
+# 3. Start Jupyter manually
+cd /workspace
+nohup jupyter lab \
+  --ip=0.0.0.0 \
+  --port=8888 \
+  --no-browser \
+  --allow-root \
+  --ServerApp.token='' \
+  --ServerApp.password='' \
+  --NotebookApp.token='' \
+  --NotebookApp.password='' \
+  --notebook-dir="/workspace" \
+  > /workspace/logs/jupyter.log 2>&1 &
+
+# 4. Check if it's running
+tail -f /workspace/logs/jupyter.log
+```
+
+**Access Jupyter:**
+- Click the HTTP Services port 8888 in RunPod
+- Or use: `https://[your-pod-id]-8888.proxy.runpod.net`
+
+### Option 3: Set as RunPod Secrets
+
+RunPod also supports secrets (more secure for tokens):
+
+1. Go to your RunPod account settings
+2. Navigate to "Secrets"
+3. Add these secrets:
+   - `JUPYTER_ENABLE` = `true`
+   - `DOWNLOAD_MODELS` = `true`
+   - `HF_TOKEN` = `hf_xxxxx` (if needed)
+4. In your template, reference them as:
+   - `{{ RUNPOD_SECRET_JUPYTER_ENABLE }}`
+   - `{{ RUNPOD_SECRET_DOWNLOAD_MODELS }}`
+   - `{{ RUNPOD_SECRET_HF_TOKEN }}`
+
+## Verification
+
+**Check if Jupyter is running:**
+```bash
+# Method 1: Check process
+ps aux | grep jupyter
+
+# Method 2: Check port
+netstat -tulpn | grep 8888
+
+# Method 3: Check logs
+cat /workspace/logs/jupyter.log
+```
+
+## Common Issues
+
+### Issue: "Empty environment variables"
+**Symptom:** Logs show `JUPYTER_ENABLE raw='' normalized=''`
+
+**Fix:**
+1. Verify you clicked "Save" in RunPod template settings
+2. Try restarting the pod (not just the container)
+3. Use Option 2 (manual start) as temporary workaround
+
+### Issue: "Port 8888 not accessible"
+**Symptom:** Can't connect to Jupyter
+
+**Fix:**
+1. Check if port 8888 is exposed in template: `8888:8888`
+2. Verify Jupyter is running: `ps aux | grep jupyter`
+3. Check firewall: RunPod should auto-configure this
+
+### Issue: "Authentication required"
+**Symptom:** Jupyter asks for token/password
+
+**Fix:**
+1. Set `JUPYTER_ALLOW_NO_AUTH=true` environment variable
+2. Or set a password: `JUPYTER_PASSWORD=YourPassword123`
+
+## Debug Commands
+
+```bash
+# Full environment dump
+env | sort
+
+# Check container logs
+docker logs [container-id]
+
+# Check all running processes
+ps aux | grep -E "jupyter|comfyui|python"
+
+# Network check
+curl -v http://localhost:8888
+```
+
+## Contact
+
+If you still have issues after trying these solutions, check:
+- RunPod logs (in pod details)
+- Container logs (in terminal)
+- GitHub issues: https://github.com/ecomtree/comfyui-cloud/issues
+

--- a/docs/RUNPOD_JUPYTER_FIX.md
+++ b/docs/RUNPOD_JUPYTER_FIX.md
@@ -66,10 +66,10 @@ RunPod also supports secrets (more secure for tokens):
    - `JUPYTER_ENABLE` = `true`
    - `DOWNLOAD_MODELS` = `true`
    - `HF_TOKEN` = `hf_xxxxx` (if needed)
-4. In your template, reference them as:
-   - `{{ RUNPOD_SECRET_JUPYTER_ENABLE }}`
-   - `{{ RUNPOD_SECRET_DOWNLOAD_MODELS }}`
-   - `{{ RUNPOD_SECRET_HF_TOKEN }}`
+4. In your container, reference them as environment variables:
+   - `$RUNPOD_SECRET_JUPYTER_ENABLE`
+   - `$RUNPOD_SECRET_DOWNLOAD_MODELS`
+   - `$RUNPOD_SECRET_HF_TOKEN`
 
 ## Verification
 

--- a/runpod-template-example.json
+++ b/runpod-template-example.json
@@ -20,7 +20,7 @@
     {
       "key": "JUPYTER_ENABLE",
       "value": "true",
-      "description": "Enable Jupyter Lab on port 8888 (default: false). IMPORTANT: Click Save after adding!"
+      "description": "Enable Jupyter Lab on port 8888 (default: false; pre-enabled in this template). IMPORTANT: Click Save after adding!"
     },
     {
       "key": "DOWNLOAD_MODELS",

--- a/runpod-template-example.json
+++ b/runpod-template-example.json
@@ -25,7 +25,7 @@
     {
       "key": "DOWNLOAD_MODELS",
       "value": "true",
-      "description": "Enable automatic download of all ComfyUI models on startup (default: false)"
+      "description": "Enable automatic download of all ComfyUI models on startup (default: false; pre-enabled in this template)"
     },
     {
       "key": "JUPYTER_ALLOW_NO_AUTH",

--- a/runpod-template-example.json
+++ b/runpod-template-example.json
@@ -29,7 +29,7 @@
     },
     {
       "key": "JUPYTER_ALLOW_NO_AUTH",
-      "value": "true",
+      "value": "false",
       "description": "Allow Jupyter without password (only for trusted environments!)"
     },
     {

--- a/runpod-template-example.json
+++ b/runpod-template-example.json
@@ -18,14 +18,34 @@
   ],
   "envVars": [
     {
+      "key": "JUPYTER_ENABLE",
+      "value": "true",
+      "description": "Enable Jupyter Lab on port 8888 (default: false). IMPORTANT: Click Save after adding!"
+    },
+    {
       "key": "DOWNLOAD_MODELS",
       "value": "true",
-      "description": "Enable automatic download of all ComfyUI models on startup"
+      "description": "Enable automatic download of all ComfyUI models on startup (default: false)"
+    },
+    {
+      "key": "JUPYTER_ALLOW_NO_AUTH",
+      "value": "true",
+      "description": "Allow Jupyter without password (only for trusted environments!)"
+    },
+    {
+      "key": "JUPYTER_PASSWORD",
+      "value": "",
+      "description": "Optional: Set Jupyter password. Leave empty to use JUPYTER_ALLOW_NO_AUTH"
     },
     {
       "key": "HF_TOKEN",
       "value": "",
-      "description": "Optional: Hugging Face token for private model downloads"
+      "description": "Optional: Hugging Face token for private model downloads. Use RunPod Secrets for security!"
+    },
+    {
+      "key": "DOWNLOAD_MAX_WORKERS",
+      "value": "4",
+      "description": "Number of parallel download workers (default: 4, max: 8)"
     }
   ],
   "volumeSize": 500,


### PR DESCRIPTION
This pull request improves compatibility and reliability for deploying Jupyter Lab and model downloads on RunPod by adding robust support for RunPod environment variables and secrets, enhanced debugging, and clearer documentation. The changes help ensure that key configuration variables are correctly detected and set, reducing startup issues and making troubleshooting easier for users.

**RunPod Environment Variable & Secret Handling:**
* Added logic in `Dockerfile` to automatically detect and set `JUPYTER_ENABLE`, `DOWNLOAD_MODELS`, and `HF_TOKEN` from both RunPod environment variables (e.g., `RUNPOD_SECRET_JUPYTER_ENABLE`) and secrets files, ensuring these settings are reliably passed to the container.

**Debugging & Diagnostics:**
* Enhanced the `Dockerfile` to print all relevant environment variables (`JUPYTER`, `DOWNLOAD`, `RUNPOD`, `HF_TOKEN`) at startup for easier troubleshooting.

**Documentation Updates:**
* Updated `README.md` with clearer instructions for setting environment variables in RunPod, emphasizing the need to click "Save," step-by-step setup, and troubleshooting tips including diagnostic commands. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R226-R227) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R237-R254)
* Added a new guide `docs/RUNPOD_JUPYTER_FIX.md` detailing common issues, solutions, manual workarounds, and verification steps for Jupyter Lab startup problems on RunPod.

**Template Improvements:**
* Expanded `runpod-template-example.json` to include more descriptive environment variables for Jupyter Lab, model downloads, authentication options, Hugging Face tokens, and parallel download configuration, with helpful descriptions for each.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds RunPod-style secret/env detection for Jupyter and model downloads, improves startup diagnostics, and updates docs/template with setup and troubleshooting.
> 
> - **Runtime (Dockerfile)**:
>   - Add detection of RunPod secrets/env (`RUNPOD_SECRET_*` and `/etc/runpod-volume/secrets/*`) for `JUPYTER_ENABLE`, `DOWNLOAD_MODELS`, and `HF_TOKEN`.
>   - Normalize flags and print concise DEBUG dump of relevant env vars at startup.
>   - Jupyter launch flow: supports password or no-auth modes; preserves current behavior and logs to `/workspace/jupyter.log`.
> - **Documentation**:
>   - README: clearer RunPod env setup steps, emphasis on Save action, and troubleshooting commands.
>   - New guide `docs/RUNPOD_JUPYTER_FIX.md` with root-cause, fixes, manual start, verification, and common issues.
> - **Template**:
>   - Expand `runpod-template-example.json` with Jupyter/auth/download env vars and descriptions, plus worker tuning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 963392f2e1edd5af4394549bc143dcb16cb15e44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RunPod Secrets support for secure environment-variable configuration, allowing Jupyter enablement and model-download controls to be set via secrets.
  * New runtime options for Jupyter authentication and download concurrency; startup now respects secret-based enablement and prints related debug info.

* **Documentation**
  * Step-by-step RunPod environment variable setup workflow and example template updates.
  * New troubleshooting guide for Jupyter Lab startup with verification and remediation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->