### PR TITLE
fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -525,9 +525,9 @@ fi
 secret_env() {
     VAR_NAME="$1"
     SECRET_VAR="RUNPOD_SECRET_${VAR_NAME}"
-    # Use indirect expansion for variable lookup
-    VAR_VALUE="${!VAR_NAME}"
-    SECRET_VALUE="${!SECRET_VAR}"
+    # Use eval for indirect expansion (compatible with sh and bash)
+    VAR_VALUE=$(eval echo "\$${VAR_NAME}")
+    SECRET_VALUE=$(eval echo "\$${SECRET_VAR}")
     if [ -z "${VAR_VALUE}" ] && [ -n "${SECRET_VALUE}" ]; then
         echo "🔍 Using ${SECRET_VAR}"
         export "${VAR_NAME}=${SECRET_VALUE}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -525,9 +525,9 @@ fi
 secret_env() {
     VAR_NAME="$1"
     SECRET_VAR="RUNPOD_SECRET_${VAR_NAME}"
-    # Use eval for indirect expansion (compatible with sh and bash)
-    VAR_VALUE=$(eval echo "\$${VAR_NAME}")
-    SECRET_VALUE=$(eval echo "\$${SECRET_VAR}")
+    # Use bash indirect expansion for variable lookup
+    VAR_VALUE="${!VAR_NAME}"
+    SECRET_VALUE="${!SECRET_VAR}"
     if [ -z "${VAR_VALUE}" ] && [ -n "${SECRET_VALUE}" ]; then
         echo "🔍 Using ${SECRET_VAR}"
         export "${VAR_NAME}=${SECRET_VALUE}"
@@ -542,7 +542,7 @@ read_secret_env() {
     VAR_NAME="$1"
     FILE_PATH="$2"
     # Only set if file exists and env var is unset
-    VAR_VALUE=$(eval echo "\$${VAR_NAME}")
+    VAR_VALUE="${!VAR_NAME}"
     if [ -f "$FILE_PATH" ] && [ -z "${VAR_VALUE}" ]; then
         echo "🔍 Reading $VAR_NAME from secrets file"
         export "${VAR_NAME}=$(cat "$FILE_PATH" 2>/dev/null || echo '')"


### PR DESCRIPTION
This pull request updates the `secret_env` function in the `Dockerfile` to improve compatibility with both `sh` and `bash` shells by switching from indirect variable expansion to using `eval`.

Shell compatibility improvement:

* Changed variable lookup in the `secret_env` function from indirect expansion (`${!VAR_NAME}`) to `eval`-based expansion (`eval echo "\${VAR_NAME}"`), ensuring compatibility with both `sh` and `bash` shells.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces eval-based env var lookups with bash indirect expansion in Dockerfile secret handling and updates related comments.
> 
> - **Runtime script (Dockerfile)**:
>   - Switch `secret_env` and `read_secret_env` variable resolution to bash indirect expansion (`${!VAR_NAME}`) instead of `eval`.
>   - Update comments to reflect bash-specific indirect expansion usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2228a8bba3e85bab6673395180de7c036d68d994. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated Docker configuration for environment variable and secret resolution: replaced eval-style indirection with safer shell-built-in indirection, improving security, compatibility, and runtime predictability across different shell environments. No public interfaces or exported entities were added, removed, or modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->