### PR TITLE
Update Dockerfile to use single quotes in HEREDOC for start script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -392,7 +392,7 @@ EOF
 
 # Create H200-optimized start script (modern HEREDOC syntax)
 # IMPORTANT: copy to /usr/local/bin/ so it works with volume mounts on /workspace
-RUN <<EOF cat > /usr/local/bin/start_comfyui_h200.sh
+RUN <<'EOF' cat > /usr/local/bin/start_comfyui_h200.sh
 #!/bin/bash
 set -e
 


### PR DESCRIPTION
This pull request makes a minor improvement to the Dockerfile by updating the heredoc syntax to use single quotes. This change ensures that the contents of the script are interpreted literally, preventing unwanted variable expansion or interpretation.

* Changed the heredoc syntax in the `RUN` command to use single quotes when generating the `start_comfyui_h200.sh` script in the Dockerfile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use single-quoted HEREDOC in Dockerfile for `start_comfyui_h200.sh` to ensure literal content (no variable expansion).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c36ba8ff196a1c8010acf9a158fd9182cbaea717. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->