### PR TITLE
Refactor secret environment variable loading in Dockerfile to use pri…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -525,9 +525,9 @@ fi
 secret_env() {
     VAR_NAME="$1"
     SECRET_VAR="RUNPOD_SECRET_${VAR_NAME}"
-    # Use bash indirect expansion for variable lookup
-    VAR_VALUE="${!VAR_NAME}"
-    SECRET_VALUE="${!SECRET_VAR}"
+    # Lookup using printenv to avoid indirect expansion during build
+    VAR_VALUE="$(printenv "$VAR_NAME")"
+    SECRET_VALUE="$(printenv "$SECRET_VAR")"
     if [ -z "${VAR_VALUE}" ] && [ -n "${SECRET_VALUE}" ]; then
         echo "🔍 Using ${SECRET_VAR}"
         export "${VAR_NAME}=${SECRET_VALUE}"
@@ -542,7 +542,7 @@ read_secret_env() {
     VAR_NAME="$1"
     FILE_PATH="$2"
     # Only set if file exists and env var is unset
-    VAR_VALUE="${!VAR_NAME}"
+    VAR_VALUE="$(printenv "$VAR_NAME")"
     if [ -f "$FILE_PATH" ] && [ -z "${VAR_VALUE}" ]; then
         echo "🔍 Reading $VAR_NAME from secrets file"
         export "${VAR_NAME}=$(cat "$FILE_PATH" 2>/dev/null || echo '')"


### PR DESCRIPTION
…ntenv for safer variable retrieval during build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use printenv to read env and RUNPOD secret variables during runtime, replacing bash indirect expansion.
> 
> - **Dockerfile/runtime script**:
>   - Update `secret_env` and `read_secret_env` to use `printenv` for resolving `JUPYTER_ENABLE`, `DOWNLOAD_MODELS`, and `HF_TOKEN` (instead of bash indirect expansion) for safer env handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb5dd80a4de902ad2bf88ca17241cf3684871b11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved environment variable handling mechanisms for enhanced reliability and consistency in configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->