### PR TITLE
Fix ComfyUI startup to use python3 interpreter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -781,7 +781,7 @@ else
 fi
 
 # Launch parameters (ComfyUI as main process)
-exec python main.py \
+exec python3 main.py \
     --listen 0.0.0.0 \
     --port 8188 \
     --highvram \


### PR DESCRIPTION
## Summary
- update the H200 start script template to invoke `python3` when launching ComfyUI so the container works even when no `python` shim exists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_6903a1e72d2483278139e95b00d9f7ff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch ComfyUI startup command to use `python3` instead of `python` in the H200 start script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77d56c1c62cc941595790c02e51c28651284df0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration to explicitly use Python 3 for application execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->